### PR TITLE
Support for connecting to random VPN server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Images are published on,
 | `PROTONVPN_TIER`          | Yes | Proton VPN Tier (0=Free, 1=Basic, 2=Pro, 3=Visionary)
 | `PROTONVPN_USERNAME`      | Yes | OpenVPN Username. This is NOT your Proton Account Username.
 | `PROTONVPN_PASSWORD`      | Yes | OpenVPN Password. This is NOT your Proton Account Password.
-| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. This value is mutually exclusive with `PROTONVPN_COUNTRY`. Only one of them can be used.
+| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. This value is mutually exclusive with `PROTONVPN_COUNTRY`. Only one of them can be used. Set it to 'RANDOM' to connect to a random server.
+
 | `PROTONVPN_COUNTRY`       | Yes | ProtonVPN two letter country code. This will choose the fastest server from this country. This value is mutually exclusive with `PROTONVPN_SERVER`. Only one of them can be used.
 | `PROTONVPN_PROTOCOL`      | No  | Protocol to use. By default `udp` is used.
 | `PROTONVPN_EXCLUDE_CIDRS` | No | Comma separated list of CIDRs to exclude from VPN. Uses split tunnel. Default is set to `169.254.169.254/32,169.254.170.2/32`
 | `PROTONVPN_DNS_LEAK_PROTECT` | No  | Setting this to `0` will disable DNS leak protection. If you wish to specify custom DNS server via `--dns` option you **MUST** set this to `0`.
-
 
 ## Run Container
 

--- a/root/etc/services.d/protonvpn/run
+++ b/root/etc/services.d/protonvpn/run
@@ -16,10 +16,13 @@ readonly SVC_CHCK="[Service - CHCK]"
 
 function connect_vpn()
 {
-  if [[ -z "$PROTONVPN_SERVER" ]] &&  [[ -n ${PROTONVPN_COUNTRY} ]]; then
+  if [[ -z "$PROTONVPN_SERVER" ]] && [[ -n ${PROTONVPN_COUNTRY} ]]; then
     echo "${SVC_CONN} Using Fastest Server from ${PROTONVPN_COUNTRY}"
     PVPN_DEBUG="${DEBUG:-0}" /usr/local/bin/protonvpn connect --cc "${PROTONVPN_COUNTRY}"
-  elif [[ -z "$PROTONVPN_COUNTRY" ]] &&  [[ -n ${PROTONVPN_SERVER} ]]; then
+  elif [[ "${PROTONVPN_SERVER^^}" == "RANDOM" ]] && [[ -n ${PROTONVPN_COUNTRY} ]]; then
+    echo "${SVC_CONN} Using Random Server"
+    PVPN_DEBUG="${DEBUG:-0}" /usr/local/bin/protonvpn connect --random
+  elif [[ -z "$PROTONVPN_COUNTRY" ]] && [[ -n ${PROTONVPN_SERVER} ]]; then
     echo "${SVC_CONN} Using Server ${PROTONVPN_SERVER}"
     PVPN_DEBUG="${DEBUG:-0}" /usr/local/bin/protonvpn connect "${PROTONVPN_SERVER}"
   else


### PR DESCRIPTION
This PR adds support for connecting to random server. I have chosen to change behaviour of the SERVER and COUNTRY variables, so that random server is chosen if neither is specified. If you prefer, I can change the code to connect to random server if COUNTRY is set to magic value `RANDOM`.