### PR TITLE
Fixed the wrong print message for config protocol

### DIFF
--- a/root/etc/cont-init.d/70-vpn-setup
+++ b/root/etc/cont-init.d/70-vpn-setup
@@ -30,8 +30,8 @@ case ${PROTONVPN_TIER} in
 esac
 
 case ${PROTONVPN_PROTOCOL} in
-  tcp | TCP)                    echo "[VPN-Config-Setup] UDP";CFG_PROTO="tcp";;
-  udp | UDP)                    echo "[VPN-Config-Setup] TCP";CFG_PROTO="udp";;
+  tcp | TCP)                    echo "[VPN-Config-Setup] TCP";CFG_PROTO="tcp";;
+  udp | UDP)                    echo "[VPN-Config-Setup] UDP";CFG_PROTO="udp";;
   *)                            echo "[VPN-Config-Setup] Invalid Proto ${PROTONVPN_PROTOCOL}, Falling back to UDP";
                                 CFG_PROTO="udp";;
 esac


### PR DESCRIPTION
## What does this do / why do we need it?

Just changes a log in the container init sequence to make it more clear what's happening.


## How this PR fixes the problem?

Simply swapped what it logs out for which protocol.


<!-- COMMIT-NOTES-BEGIN -->

There was a small issue where TCP would be printed to the logs when it was in fact using UDP. Just swapped what it prints out.

<!-- COMMIT-NOTES-END -->
