### PR TITLE
Fixing misspelt 'labels' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ networks:
     internal: true
 ```
 
-- It is essential to apply labes and expose port on protonvpn container instead of your application. This is because your application container shares network namepsce of protonvpn container.
+- It is essential to apply labels and expose port on protonvpn container instead of your application. This is because your application container shares network namepsce of protonvpn container.
 - If using Traefik, apply labels to protonvpn container, and expose your application ports.
 
 ## Health-checks


### PR DESCRIPTION
There was just a small spelling mistake in the README that was bugging me.

<!-- Thank you for your contribution -->


## What does this do / why do we need it?

Improves readability of the README, allowing people to better understand what's intended.


## How this PR fixes the problem?

Simply fixes the small spelling mistake (it happens, I'm just a perfectionist)
