### PR TITLE
feat: Add P2P option to PROTONVPN_SERVER

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Images are published on [GitHub Container Registry][ghcr].
 | `PROTONVPN_TIER`          | Yes | Proton VPN Tier (0=Free, 1=Basic, 2=Pro, 3=Visionary)
 | `PROTONVPN_USERNAME`      | Yes | OpenVPN Username. This is **NOT** your Proton Account Username.
 | `PROTONVPN_PASSWORD`      | Yes | OpenVPN Password. This is **NOT** your Proton Account Password.
-| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. This value is mutually exclusive with `PROTONVPN_COUNTRY`. Only one of them can be used. Set it to `RANDOM` to connect to a random server.
+| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. This value is mutually exclusive with `PROTONVPN_COUNTRY`. Only one of them can be used. Set it to `RANDOM` to connect to a random server. Set it to `P2P` to connect to fastest P2P server (does not work for free accounts)a.
 | `PROTONVPN_COUNTRY`       | Yes | ProtonVPN two letter country code. This will choose the fastest server from this country. This value is mutually exclusive with `PROTONVPN_SERVER`. Only one of them can be used.
 | `PROTONVPN_PROTOCOL`      | No  | Protocol to use. By default `udp` is used.
 | `PROTONVPN_EXCLUDE_CIDRS` | No  | Comma separated list of CIDRs to exclude from VPN. Uses split tunnel. Default is set to `169.254.169.254/32,169.254.170.2/32`

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Images are published on [GitHub Container Registry][ghcr].
 | `PROTONVPN_TIER`          | Yes | Proton VPN Tier (0=Free, 1=Basic, 2=Pro, 3=Visionary)
 | `PROTONVPN_USERNAME`      | Yes | OpenVPN Username. This is **NOT** your Proton Account Username.
 | `PROTONVPN_PASSWORD`      | Yes | OpenVPN Password. This is **NOT** your Proton Account Password.
-| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. This value is mutually exclusive with `PROTONVPN_COUNTRY`. Only one of them can be used. Set it to `RANDOM` to connect to a random server. Set it to `P2P` to connect to fastest P2P server (does not work for free accounts)a.
+| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. This value is mutually exclusive with `PROTONVPN_COUNTRY`. Only one of them can be used. Set it to `RANDOM` to connect to a random server. Set it to `P2P` to connect to fastest P2P server (does not work for free accounts).
 | `PROTONVPN_COUNTRY`       | Yes | ProtonVPN two letter country code. This will choose the fastest server from this country. This value is mutually exclusive with `PROTONVPN_SERVER`. Only one of them can be used.
 | `PROTONVPN_PROTOCOL`      | No  | Protocol to use. By default `udp` is used.
 | `PROTONVPN_EXCLUDE_CIDRS` | No  | Comma separated list of CIDRs to exclude from VPN. Uses split tunnel. Default is set to `169.254.169.254/32,169.254.170.2/32`

--- a/root/etc/services.d/protonvpn/run
+++ b/root/etc/services.d/protonvpn/run
@@ -32,6 +32,9 @@ function connect_vpn()
   elif [[ ${PROTONVPN_SERVER} == "RANDOM" ]] && [[ -z ${PROTONVPN_COUNTRY} ]]; then
     echo "${SVC_CONN} Using Random Server"
     PVPN_DEBUG="${DEBUG:-0}" protonvpn connect --random
+  elif [[ ${PROTONVPN_SERVER} == "P2P" ]] && [[ -z ${PROTONVPN_COUNTRY} ]]; then
+    echo "${SVC_CONN} Using Fastest P2P Server"
+    PVPN_DEBUG="${DEBUG:-0}" protonvpn connect --p2p
   elif [[ -z $PROTONVPN_COUNTRY ]] && [[ -n ${PROTONVPN_SERVER} ]]; then
     echo "${SVC_CONN} Using Server ${PROTONVPN_SERVER}"
     PVPN_DEBUG="${DEBUG:-0}" protonvpn connect "${PROTONVPN_SERVER}"


### PR DESCRIPTION

<!-- Thank you for your contribution -->


## What does this do / why do we need it?

This enables connecting to the paid P2P servers.

## How this PR fixes the problem?

Adds a P2P switch to PROTONVPN_SERVER environment variable.
Setting it will connect to fastest P2P server.  Requires a paid plan to work.


<!-- COMMIT-NOTES-BEGIN -->
feat: Add P2P option to PROTONVPN_SERVER

Allows setting PROTONVPN_SERVER to P2P
Will connect to fastest P2P server.
Requires a paid plan to work.

<!-- COMMIT-NOTES-END -->
