### PR TITLE
docs: Add ipinfo.io unauthenticated rate limits to known issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ See [Troubleshooting](./docs/troubleshooting.md).
 
 - Kill switch is **NOT** reliable. This is due to the way protonvpn cli works because on issuing reconnect they remove
 re-initialize iptable rules which removes block on outgoing connections for a short duration until iptable rules are applied again.
+- The endpoint used by [healthcheck](https://github.com/tprasadtp/protonvpn-docker/blob/master/root/usr/local/bin/healthcheck) has a [rate limit of 50,000 unauthenticated requests per month](https://ipinfo.io/faq/article/61-usage-limit-free-plan). A `PROTONVPN_CHECK_INTERVAL` value of less than 60 seconds will likely hit this rate limit earlier in the month resulting in repeated disconnects as the healthcheck will fail.
 
 ## DNS & Split Tunneling
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ See [Troubleshooting](./docs/troubleshooting.md).
 
 - Kill switch is **NOT** reliable. This is due to the way protonvpn cli works because on issuing reconnect they remove
 re-initialize iptable rules which removes block on outgoing connections for a short duration until iptable rules are applied again.
-- The endpoint used by [healthcheck](https://github.com/tprasadtp/protonvpn-docker/blob/master/root/usr/local/bin/healthcheck) has a [rate limit of 50,000 unauthenticated requests per month](https://ipinfo.io/faq/article/61-usage-limit-free-plan). A `PROTONVPN_CHECK_INTERVAL` value of less than 60 seconds will likely hit this rate limit earlier in the month resulting in repeated disconnects as the healthcheck will fail.
+- The endpoint used by [healthcheck](https://github.com/tprasadtp/protonvpn-docker/blob/master/root/usr/local/bin/healthcheck) has a rate limit of 1,000 unauthenticated requests per day. A `PROTONVPN_CHECK_INTERVAL` value of less than 90 seconds will likely hit this rate limit earlier in the month resulting in repeated disconnects as the healthcheck will fail.
 
 ## DNS & Split Tunneling
 


### PR DESCRIPTION
<!-- Thank you for your contribution -->


## What does this do / why do we need it?
If the `PROTONVPN_CHECK_INTERVAL` value is set to lower than 90 seconds, users will eventually hit the rate limits imposed by [ipinfo.io for unauthenticated requests](https://ipinfo.io/faq/article/61-usage-limit-free-plan) - and it turns out that this rate is actually 1,000 requests/day for completely unauthenticated calls. For example, with a 30 second check users would hit this rate limit after only 8 hours, and the VPN connection would then repeatedly flap as the country check will return a `null`.

I had unknowingly set the health check to timeout at a value of 30 seconds, and this caused the VPN connection to flap after a few weeks. It turns out this is due to a 429 response from ipinfo.io:

```
[Service - CHCK] Is Service Disconnecting: 0
[Service - CHCK] #1 Failed!
[Service - CHCK] connected to #null instead of #CA
```

```
root@030b9707fcf9:/# curl \
>     --max-time 20 \
>     --silent \
>     --location \
>     https://ipinfo.io | jq -r '.country'
null

root@030b9707fcf9:/# curl -vvv https://ipinfo.io
*   Trying 34.117.59.81:443...
* TCP_NODELAY set
* Connected to ipinfo.io (34.117.59.81) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=ipinfo.io
*  start date: May 14 20:52:37 2021 GMT
*  expire date: Aug 12 21:52:37 2021 GMT
*  subjectAltName: host "ipinfo.io" matched cert's "ipinfo.io"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1D4
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x56336c089e10)
> GET / HTTP/2
> Host: ipinfo.io
> user-agent: curl/7.68.0
> accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 100)!
< HTTP/2 429
< access-control-allow-origin: *
< x-frame-options: DENY
< x-xss-protection: 1; mode=block
< x-content-type-options: nosniff
< referrer-policy: strict-origin-when-cross-origin
< content-type: application/json; charset=utf-8
< content-length: 210
< date: Sat, 22 May 2021 15:44:11 GMT
< x-envoy-upstream-service-time: 1
< via: 1.1 google
< alt-svc: clear
<
{
  "status": 429,
  "error": {
    "title": "Rate limit exceeded",
    "message": "You've hit the daily limit for the unauthenticated API.  Create an API access token by s
igning up to get 50k req/month."
  }
```

## How this PR fixes the problem?

This informs users that setting a value of under 90 seconds is not advised, as they will likely encounter these same rate limiting issues if the VPN repeatedly reconnects to the same ProtonVPN server.

## Additional Comments (if any)

I suspect this problem may be exacerbated depending on how ProtonVPN handles NATing of outbound connections. Even with a 60 second interval, if two connections share the same outbound IP from the ProtonVPN node, it's likely that both will start hitting 429 responses and cause the connection to flap.

More broadly, you may wish to consider a change to https://github.com/TheHowl/ip.zxq.co for the healthcheck, as this service offers comparable functionality without rate limiting. I've opened https://github.com/tprasadtp/protonvpn-docker/pull/50 for that, which would remove the need for this documentation update entirely, while also allowing for more rapid healthcheck intervals.
