### PR TITLE
Replacing ipinfo.io with ip.zxq.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ networks:
 
 ## Health-checks
 
-There is a `healthcheck` script available under /usr/local/bin (Added in 2.2.2-hotfix2). It will use `https://ipinfo.io` to verify the country to which VPN is connected. By default service will keep checking every `PROTONVPN_CHECK_INTERVAL` _(default = 60)_ seconds using the same api endpoint, script is only added for convenience.
+There is a `healthcheck` script available under /usr/local/bin (Added in 2.2.2-hotfix2). It will use `https://ip.zxq.co` to verify the country to which VPN is connected. By default service will keep checking every `PROTONVPN_CHECK_INTERVAL` _(default = 60)_ seconds using the same api endpoint, script is only added for convenience.
 
 ## Changelog
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,7 +24,7 @@ This depends on your shell. Please consult your shell's manpage/docs for how to 
 1. Visit the link in your browser.
 1. If for some reason you still get timeout errors, please specify output of following when running inside protonvpn container via `docker exec -it protonvpn bash`, when opening your issue.
     - `ip r`
-    - `curl -sSfL ipinfo.io`
+    - `curl -sSfL ip.zxq.co`
 
 ## DNS and Healthchecks
 

--- a/root/etc/services.d/protonvpn/run
+++ b/root/etc/services.d/protonvpn/run
@@ -64,7 +64,7 @@ function api_check()
     --max-time 20 \
     --silent \
     --location \
-    https://ipinfo.io | jq -r '.country')"
+    https://ip.zxq.co | jq -r '.country')"
 
   if [[ -z ${PROTONVPN_COUNTRY} ]]; then
     PROTONVPN_COUNTRY="$(python3 /usr/local/bin/proton-srv-country)"

--- a/root/usr/local/bin/healthcheck
+++ b/root/usr/local/bin/healthcheck
@@ -13,7 +13,7 @@ CONNECTED_COUNTRY="$(curl \
     --max-time 20 \
     --silent \
     --location \
-    https://ipinfo.io | jq -r '.country')"
+    https://ip.zxq.co | jq -r '.country')"
 
 if [[ ${CONNECTED_COUNTRY} == "${PROTONVPN_COUNTRY}" ]]; then
   if [[ ${PROTONVPN_HEALTHCHECK_SILENT} -ne 1 ]]; then


### PR DESCRIPTION
<!-- Thank you for your contribution -->


## What does this do / why do we need it?

As outlined in https://github.com/tprasadtp/protonvpn-docker/pull/50, `ipinfo.io` has pretty restrictive rate limits which means that users will invariably wind up with their VPN connection flapping after a few hours, even using the default 60s `healthcheck` value.

## How this PR fixes the problem?

This replaces the dependancy on `ipinfo.io` with `ip.zxq.co`. `ip.zxq.co` offers identical functionality, however it is not rate limited and [is an open source project](https://github.com/thehowl/ip.zxq.co) (so in theory, it could be brought up elsewhere and hosted specifically for a service like this if `ip.zxq.co` were to go down).


## Additional Comments (if any)

This removes the need for https://github.com/tprasadtp/protonvpn-docker/pull/50 - only one would be needed, and this is likely the better choice for ease of use.
