### PR TITLE
[FEAT] Change default of PROTONVPN_SERVER

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Images are published on [GitHub Container Registry][ghcr].
 | `PROTONVPN_TIER`          | Yes | Proton VPN Tier (0=Free, 1=Basic, 2=Pro, 3=Visionary)
 | `PROTONVPN_USERNAME`      | Yes | OpenVPN Username. This is **NOT** your Proton Account Username.
 | `PROTONVPN_PASSWORD`      | Yes | OpenVPN Password. This is **NOT** your Proton Account Password.
-| `PROTONVPN_SERVER`        | Yes | ProtonVPN server to connect to. See `PROTONVPN_SERVER` for more info.
+| `PROTONVPN_SERVER`        | No | ProtonVPN server to connect to. See `PROTONVPN_SERVER` for more info.
 | `PROTONVPN_PROTOCOL`      | No  | Protocol to use. By default `udp` is used.
 | `PROTONVPN_EXCLUDE_CIDRS` | No  | Comma separated list of CIDRs to exclude from VPN. Uses split tunnel. Default is set to `169.254.169.254/32,169.254.170.2/32`
 | `PROTONVPN_DNS_LEAK_PROTECT` | No  | (Interger) Setting this to `0` will disable DNS leak protection. If you wish to specify custom DNS server via `--dns` option or running on k8s, you **MUST** set this to `0`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Images are published on [GitHub Container Registry][ghcr].
   - If set to `RANDOM`, a random server will be chosen which is compatible with your plan.
   - If set to `P2P` will choose fastest `P2P` server. Please note that this requires setting correct plan in `PROTONVPN_TIER`.
   - If none of the above are true, container will attempt to connect to this server and fail if it is not possible. Please note that `Secure Core` servers are only available with pro plan and above.
-
+  - If `PROTONVPN_SERVER` is unset, then the fastest server is connected to.
 ## Run Container
 
 ```bash

--- a/root/etc/services.d/protonvpn/run
+++ b/root/etc/services.d/protonvpn/run
@@ -38,8 +38,9 @@ trap _term SIGTERM SIGINT
 function connect_vpn() {
 
   if [[ -z ${PROTONVPN_SERVER} ]]; then
-    log_error "Specify PROTONVPN_SERVER(${PROTONVPN_SERVER})"
-    exit 4
+    log_notice "Connecting to fastest server"
+    PVPN_DEBUG="${DEBUG:-0}" protonvpn connect -f 
+    
   fi
 
   if [[ ${PROTONVPN_SERVER^^} =~ ^[A-Z]{2}$ ]]; then


### PR DESCRIPTION


<!-- Thank you for your contribution -->


## What does this do / why do we need it?
Since protonvpn connect -f is not an option right now, have not specifying the PROTONVPN_SERVER to indicate connection to fastest server.


## Additional Comments (if any)




<!-- COMMIT-NOTES-BEGIN -->


<!-- COMMIT-NOTES-END -->
