### PR TITLE
fix: Conditional checks for `PROTONVPN_TIER`

### DIFF
--- a/root/etc/services.d/protonvpn/run
+++ b/root/etc/services.d/protonvpn/run
@@ -51,7 +51,7 @@ function connect_vpn() {
     PVPN_DEBUG="${DEBUG:-0}" protonvpn connect --random
 
   elif [[ ${PROTONVPN_SERVER} == "P2P" ]]; then
-    if [[ ${CFG_TIER} -lt 1 ]]; then
+    if [[ ${PROTONVPN_TIER} -lt 1 ]]; then
       log_error "Using P2P requires basic plan or above!"
       exit 4
     else


### PR DESCRIPTION
<!-- Thank you for your contribution -->


## What does this do / why do we need it?

Using CFG_TIER in 'run' returns an empty value causing immediate failures.  Use PROTONVPN_TIER as documented instead.

## How this PR fixes the problem?

```
+ [[ '' -lt 1 ]]
+ log_error 'Using P2P requires basic plan or above!'
+ __logger_core_event_handler error 'Using P2P requires basic plan or above!'
```

2021-09-23 19:30:36+00:00 [INFO  ] PROTONVPN_CHECK_INTERVAL is set to #60
2021-09-23 19:30:36+00:00 [INFO  ] Reconnect threshold is #3
2021-09-23 19:30:36+00:00 [INFO  ] Checking orphaned openvpn process
2021-09-23 19:30:36+00:00 [INFO  ] This appears to be a fresh start!
2021-09-23 19:30:36+00:00 [ERROR ] Using P2P requires basic plan or above!
2021-09-23 19:30:37+00:00 [INFO  ] PROTONVPN_CHECK_INTERVAL is set to #60
2021-09-23 19:30:37+00:00 [INFO  ] Reconnect threshold is #3
2021-09-23 19:30:37+00:00 [INFO  ] Checking orphaned openvpn process
2021-09-23 19:30:37+00:00 [INFO  ] This appears to be a fresh start!
2021-09-23 19:30:37+00:00 [ERROR ] Using P2P requires basic plan or above!
2021-09-23 19:30:38+00:00 [INFO  ] PROTONVPN_CHECK_INTERVAL is set to #60
2021-09-23 19:30:38+00:00 [INFO  ] Reconnect threshold is #3
2021-09-23 19:30:38+00:00 [INFO  ] Checking orphaned openvpn process
2021-09-23 19:30:38+00:00 [INFO  ] This appears to be a fresh start!
2021-09-23 19:30:38+00:00 [ERROR ] Using P2P requires basic plan or above!

## Additional Comments (if any)

Another workaround is to define CFG_TIER as a container environment variable.

<!-- COMMIT-NOTES-BEGIN -->


<!-- COMMIT-NOTES-END -->
