### PR TITLE
Allow checking exit ips for servers with the same domain

### DIFF
--- a/root/usr/bin/healthcheck
+++ b/root/usr/bin/healthcheck
@@ -37,13 +37,23 @@ logging.debug(f"Reading {SRV_INFO}")
 with open(SRV_INFO, "r") as f:
     servers = json.load(f)
     connected_server_ips = []
+    connected_server_domain = "unknown"
+
+    # Find the logical server domain
     for logical_server in servers["LogicalServers"]:
-        # IF logical server name matches
         if logical_server["Name"] == connected_server:
-            # Iterate over servers
-            for server in logical_server["Servers"]:
-                # Get Their IPs and append to allow list
-                connected_server_ips.append(server["ExitIP"])
+            connected_server_domain = logical_server["Domain"]
+
+    if connected_server_domain != "unknown":
+        for logical_server in servers["LogicalServers"]:
+            # IF logical server domain matches
+            if logical_server["Domain"] == connected_server_domain:
+                # Iterate over servers
+                for server in logical_server["Servers"]:
+                    # Get Their IPs and append to allow list
+                    connected_server_ips.append(server["ExitIP"])
+    else:
+        logging.debug(f"Unknown server domain for: {connected_server}")        
 
 logging.debug(f"Allowed IPs: {connected_server_ips}")
 


### PR DESCRIPTION
## What does this do / why do we need it?

Addresses the problem found in https://github.com/tprasadtp/protonvpn-docker/issues/87
For some reason the protonvpn-cli reports a server to whcih we are connected to, and the exit ip does not match that server, but matches one of the similar servers in the same region/domain


## How this PR fixes the problem?

Instead of checking the Exit IP of the server with the same name, the healthcheck now get the domain for that server, and gathers all Exit IPs for servers with the same domain, extending the valid Exit IPs, and thus matching the correct one if the user is actually connected to the VPN


## Additional Comments (if any)

<!-- COMMIT-NOTES-BEGIN -->


<!-- COMMIT-NOTES-END -->
