### PR TITLE
fix: Install iputils-ping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN --mount=type=tmpfs,target=/downloads/ \
     dialog \
     python3-pip \
     cron \
+    iputils-ping \
     && ARCH="$(uname -m)" \
     && export ARCH \
     && if [ "$ARCH" = "x86_64" ]; then \


### PR DESCRIPTION
<!-- Thank you for your contribution -->


## What does this do / why do we need it?

This PR install `iputils-ping` package. Without it, `protonvpn status` produces the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/protonvpn", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/protonvpn_cli/cli.py", line 73, in main
    cli()
  File "/usr/local/lib/python3.8/dist-packages/protonvpn_cli/cli.py", line 139, in cli
    connection.status()
  File "/usr/local/lib/python3.8/dist-packages/protonvpn_cli/connection.py", line 385, in status
    ping = subprocess.run(["ping", "-c", "1", dns_server],
  File "/usr/lib/python3.8/subprocess.py", line 493, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'ping'
```


## Additional Comments (if any)



<!-- COMMIT-NOTES-BEGIN -->


<!-- COMMIT-NOTES-END -->
