### PR TITLE
Added natpmpc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN --mount=type=tmpfs,target=/downloads/ \
     dialog \
     python3-pip \
     cron \
+    natpmpc \
     && ARCH="$(uname -m)" \
     && export ARCH \
     && if [ "$ARCH" = "x86_64" ]; then \


### PR DESCRIPTION
Added natpmpc to configure Port Forwarding within the container

<!-- Thank you for your contribution -->


## What does this do / why do we need it?

This PR adds the package `natpmpc` inside the container, in order to have the Port Forwarding feature


## How this PR fixes the problem?

It only installs the package. We still must look into a way of implementing the port forwarding (create the request, keep the port forwarding open, publish the port forwarded into a file that could be read from another container)


## Additional Comments (if any)

{Please write here}



<!-- COMMIT-NOTES-BEGIN -->


<!-- COMMIT-NOTES-END -->
