### PR TITLE
docs(fix): change image references to use unstable tag, fix typo in docker compose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -27,6 +27,8 @@ body:
       options:
         - label: I have verified that the servers I am trying to connect to are available under my plan.
           required: true
+        - label: I have verified that my generated Wireguard private keys are valid and have required features (Netshield Ad-blocker, VPN accelerator etc) are enabled.
+          required: true
 
   - type: input
     id: arch
@@ -109,7 +111,7 @@ body:
       description: |
         - Check common troubleshooting steps.
       options:
-        - label: I have read [FAQ](./docs/faq.md) and [Troubleshooting](./docs/help.md).
+        - label: I have read [FAQ](https://github.com/tprasadtp/protonvpn-docker/blob/master/docs/faq.md) and [Troubleshooting](https://github.com/tprasadtp/protonvpn-docker/blob/master/docs/help.md).
           required: true
         - label: I am **NOT** using container runtime which use user-mode networking, [Docker Rootless](https://docs.docker.com/engine/security/rootless/), [gVisor](https://gvisor.dev), [Podman Rootless](https://github.com/containers/podman/blob/main/rootless.md) etc.
           required: true
@@ -119,7 +121,7 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Container/Pod/systemd Log output
+      label: Container/Pod/systemd log output
       description: |
         - What do you see when you run the script with debug logs enabled
           - Set env variable `DEBUG` to 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,18 @@ updates:
       day: "saturday"
     pull-request-branch-name:
       separator: "-"
+
+  - package-ecosystem: github-actions
+    labels:
+      - "dependabot"
+      - "dependencies"
+      - "dep/github-actions"
+      - "luna/autoupdate"
+    commit-message:
+      prefix: "ci(deps):"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    pull-request-branch-name:
+      separator: "-"


### PR DESCRIPTION
- Fix typo in reference compose file, `port` -> `ports.` Fixes #187
- Changes all image references to use `unstable` tag. This is side effect of 
[this](https://github.com/tprasadtp/protonvpn-docker/blob/121293959b4b4a896bae4c28a97d082e62c40e79/.goreleaser.yml#L250) as beta/rc/alpha tags are not promoted to stable.
- Add a note to use unstable images. This should also fix #188, 
as `latest` tag on image `protonwire` was invalid and has been removed.