### PR TITLE
docs: add note about old automatic server selection not being supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,13 @@ This should be server name like `NL-FREE#1`(or `NL-FREE-1`) or domain name like,
 
 > **Warning**
 >
-> Script cannot validate if specified server is available under your plan.
+> - Script cannot validate if specified server is available under your plan.
 > Its user's responsibility to ensure that server specified is available
 > under your subscription and supports required features, like P2P, Streaming etc.
 > Use `--p2p`, `--streaming`, `--secure-core` flags to enable client side validations.
+> - Automatic server selection for `P2P`, `RANDOM` and other shortcuts are not supported.
+> Use a fully qualified DNS name (as shown in ProtonVPN website) or a server name like `NL-#1`.
+> See [this](https://github.com/tprasadtp/protonvpn-docker/blob/master/docs/faq.md#why-automatic-server-selection-is-not-supported) for more info.
 
 ## KillSwitch
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,11 +2,11 @@
 
 ## Why automatic server selection is not supported
 
-- This is caused by API changes ProtonVPN.
-- To automatic server selection, it requires authenticating  to proton API via username and password!.
-There are no scoped oauth tokens and minted access tokens have full access to Proton API including payments and Email!!.
+- This is caused by changes to ProtonVPN API.
+- To perform automatic server selection, it requires authenticating  to proton API via username and password!. There are no scoped OAuth tokens and minted access tokens have full access to Proton API including payments and Email!!.
 - Fastest server selection also depends on geo-location and latency info to populate server `.Score`.
-Due to lack of documentation on how `.Score` is computed, automatic server selection is not supported.
+Due to lack of documentation on how `.Score` is computed and it depending on geo-location,
+automatic server selection is not supported.
 
 ## How to check if an address is being routed via VPN via CLI
 


### PR DESCRIPTION
This should help users transitioning from v5 and close issues like (#204)