### PR TITLE
fix: IPv6 checks when kernel module is not present

### DIFF
--- a/protonwire
+++ b/protonwire
@@ -406,7 +406,9 @@ function __is_valid_ipcheck_url() {
 }
 
 function __is_ipv6_disabled() {
-    if [[ $(sysctl -n net.ipv6.conf.all.disable_ipv6) == "1" ]]; then
+    if [[ $(cat /sys/module/ipv6/parameters/disable) == "1" ]]; then
+        return 0
+    elif [[ $(sysctl -n net.ipv6.conf.all.disable_ipv6) == "1" ]]; then
         return 0
     elif [[ $(sysctl -n net.ipv6.conf.default.disable_ipv6) == "1" ]]; then
         return 0

--- a/protonwire
+++ b/protonwire
@@ -408,6 +408,8 @@ function __is_valid_ipcheck_url() {
 function __is_ipv6_disabled() {
     if [[ $(cat /sys/module/ipv6/parameters/disable) == "1" ]]; then
         return 0
+    elif [[ $(cat /sys/module/ipv6/parameters/disable_ipv6) == "1" ]]; then
+        return 0
     elif [[ $(sysctl -n net.ipv6.conf.all.disable_ipv6) == "1" ]]; then
         return 0
     elif [[ $(sysctl -n net.ipv6.conf.default.disable_ipv6) == "1" ]]; then


### PR DESCRIPTION
Cheers!

The current checks for IPv6 being disabled assume the [Kernel module](https://docs.kernel.org/networking/ipv6.html) is present, which is not always the case.