### PR TITLE
docs: prioritize compose file over docker/podman, use custom bridge network in examples

### DIFF
--- a/docs/examples/container-protonwire.service
+++ b/docs/examples/container-protonwire.service
@@ -55,12 +55,14 @@ TimeoutStartSec=180
 # - Environment variables are read from /etc/protonwire/*.env files
 #   and are only passed down if they are defined.
 ExecStartPre=podman rm --force --depend --ignore --time 20 protonwire
+ExecStartPre=podman network create protonwire --ignore --driver=bridge
 ExecStart=podman run \
     --name=protonwire \
+    --network=protonwire \
+    --init \
     --detach \
     --replace \
     --tz=local \
-    --init \
     --tmpfs=/tmp \
     --secret=protonwire-private-key,mode=600 \
     --env=PROTONVPN_SERVER \


### PR DESCRIPTION
Attempts to address a workaround for bug #178 and Also #155.

It is **not** possible to solve this with docker.  Docker lacks concept of container readiness nor it supports `sd_notify`. 

However with [sd_notify][] support for the container image(added in 7.0) and podman natively passing [NOTIFY_SOCKET][] to the containers, it is possible to start dependent containers only when VPN is up and healthy. (This requires user to not disable IP checks, i.e. IPCHECK_INTERVAL is not 0). Obviously this requires running containers as systemd units.
Examples should provide a way to achieve this. 


Known Bugs/Issues:

- Script/unit exits with non zero exit code on TERM signal.
- Reverse proxy with service discovey (like traefik), **MUST NOT** use the VPN. It MUST only use
the network created i.e protonwire.
- Containers using VPN **MUST NOT** use macvlan or ipvlan network.
- Podman network created is not deleted even when stopping or 
disabling the service. This is intentional.
- aardvark-dns **WILL NOT** work in containers using the VPN.
- podman in Ubuntu/Debin repositories are most likely too old. 
Please install podman from kubic repositories as per 
https://podman.io/docs/installation#installing-on-linux

[sd_notify]: https://www.freedesktop.org/software/systemd/man/sd_notify.html
[NOTIFY_SOCKET]: https://docs.podman.io/en/latest/markdown/options/sdnotify.html
[aardvark-dns]: https://github.com/containers/aardvark-dns