### PR TITLE
fix: revert flock usage and clarify DNS queries

### DIFF
--- a/.github/ISSUE_TEMPLATE/metadata.yml
+++ b/.github/ISSUE_TEMPLATE/metadata.yml
@@ -32,7 +32,7 @@ body:
   - type: dropdown
     id: dns-protocol
     attributes:
-      label: DNS Protocol
+      label: Host DNS Protocol
       options:
         - Default DNS resolver
         - DNS over HTTPS (DoH)

--- a/.github/ISSUE_TEMPLATE/support-request.yml
+++ b/.github/ISSUE_TEMPLATE/support-request.yml
@@ -1,0 +1,44 @@
+name: Support Request
+description: Support Request
+title: ""
+labels: ["help"]
+body:
+  # version
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        - Version of the package/container or commit hash
+        - If unable to detect or not applicable, leave the field as is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: support-info
+    attributes:
+      label: Support Request
+      description: |
+        Details of your support request.
+        Please be specific. Include details with relevant links/data.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: code-of-conduct
+    attributes:
+      label: Code of Conduct & PII Redaction
+      description: |
+        By submitting this issue, you agree to follow code of conduct for this repository.
+        In case the repository is missing code of conduct, Contributor Covenant code of conduct applies.
+        Please also ensure that you remove or redact any sensitive personally identifying information
+        like IP addresses and secrets like your API keys from logs and report included here.
+      options:
+        - label: I have verified that this feature request is not a duplicate and is not not addressed by the [FAQ](https://github.com/tprasadtp/protonvpn-docker/blob/master/docs/faq.md) and [Troubleshooting](https://github.com/tprasadtp/protonvpn-docker/blob/master/docs/help.md).
+          required: true
+        - label: This is not a bug report or feature request.
+          required: true
+        - label: I agree to follow this project's Code of Conduct.
+          required: true
+        - label: I have removed any sensitive personally identifying information(PII) and secrets from in this issue report.
+          required: true

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -202,9 +202,22 @@ Bulk of the work is done via `scripts/generate-server-metadata`
 - https://protonwire-api.vercel.app/v1/server (default)
 - https://tprasadtp.github.io/protonvpn-docker/v1/server (beta)
 
+## LAN/Local DNS Server and API endpoints
+
+By default ProtonVPN's DNS servers are used _after_ the connection is up and running.
+However, some DNS queries **MUST** go through default gateway/router when the wireguard interface is not up or configured. However effort is made to switch to ProtonVPN DNS server as soon as the Wireguard link is up. As metadata endpoints can be queried before the VPN is setup,
+you might need to allowlist following DNS names from your local DNS server (Pi-Hole, PFSense etc.)
+or your gateway/router.
+
+Do note that changes to this list is **NOT** covered by semver compatibility
+guarantees. If your are _not_ using default metadata and ip check endpoints this can be ignored.
+
+- `protonwire-api.vercel.app`
+- `icanhazip.com`
+
 ## Known Issues
 
-- Running multiple instances of this __outside of containers__ on same host is not supported.
+- Running multiple instances of this __outside of containers__ on _same host_ is not supported.
 
 ## Kubernetes
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -123,7 +123,7 @@ ip -6 rule | grep 51822 | cut -f 1 -d ':' | xargs ip rule del priority
 
 ## Manually Disconnecting from VPN
 
-Please use `protonwire disconnect` optionally with (`--kill-switch` flag) as it handles things properly. If not possible, try the following.
+Please use `protonwire disconnect --kill-switch` as it handles things properly. If not possible, try the following.
 
 - Restore the DNS if using systemd-resolved via,
     ```
@@ -133,20 +133,18 @@ Please use `protonwire disconnect` optionally with (`--kill-switch` flag) as it 
     ```bash
     resolvconf -f -d protonwire0.wg
     ```
-- If running version 7.2.0 and and later and **NOT** using systemd-resolved (like in containers)  restore the DNS using following commands.
+- If running version 7.2.0 and and later and **NOT** using systemd-resolved (like in containers) restore the DNS using following commands.
     ```bash
     cat /etc/resolv.conf.protonwire > /etc/resolv.conf && rm /etc/resolv.conf.protonwire
     ```
-
-```bash
-resolvectl revert protonwire0   # only if using systemd-resolved
-resolvconf -f -d protonwire0.wg # only if not using systemd-resolved
-ip -4 rule del not fwmark 51821 table 51821
-ip -6 rule del not fwmark 51821 table 51821
-ip -4 route flush table 51821
-ip -6 route flush table 51821
-ip link del protonwire0
-```
+- Remove routing rules and interfaces
+    ```bash
+    ip -4 rule del not fwmark 51821 table 51821
+    ip -6 rule del not fwmark 51821 table 51821
+    ip -4 route flush table 51821
+    ip -6 route flush table 51821
+    ip link del protonwire0
+    ```
 
 [emptyDir]: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
 [docker-compse-volumes]: https://docs.docker.com/compose/compose-file/compose-file-v3/#long-syntax-3

--- a/protonwire
+++ b/protonwire
@@ -329,7 +329,7 @@ function __is_valid_ipcheck_url() {
         local curl_rc="-1"
         local curl_opts="-sSfL"
         if __is_debug; then
-            curl_opts="-vvvfL"
+            curl_opts="-vfL"
         fi
         {
             curl "${curl_opts}" -m 20 -A 'protonwire/v7' -o "${__PROTONWIRE_HCR}" \
@@ -623,7 +623,7 @@ function __check_tools() {
         "timeout" # coreutils
         "wg"      # wireguard-tools | wireguard-tools-wg
         "sysctl"  # procps
-        "flock"   # flock | linux-utils
+        # "flock"   # flock | linux-utils
     )
 
     # Detect how to update DNS and add required commands to list of commands to check
@@ -1154,11 +1154,10 @@ function protonvpn_fetch_metadata() {
         local curl_rc="-1"
         local curl_opts="-sSfL"
         if __is_debug; then
-            curl_opts="-vvvfL"
+            curl_opts="-vfL"
         fi
         # we use wait to ensure the term signals can be handled properly
-        { flock --timeout 30 --conflict-exit-code 32 "${__PROTONWIRE_SRV_INFO_FILE}.lock" \
-            curl "${curl_opts}" -m 30 -A 'protonwire/v7' -o "${__PROTONWIRE_SRV_INFO_FILE}.bak" \
+        { curl "${curl_opts}" -m 30 -A 'protonwire/v7' -o "${__PROTONWIRE_SRV_INFO_FILE}.bak" \
             "${api_call}" 2>&1 | log_tail "curl" & }
         wait $!
         curl_rc="$?"
@@ -1326,13 +1325,12 @@ function __protonvpn_verify_connection() {
     local hc_response_rc=-1
     local curl_opts="-sSfL"
     if __is_debug; then
-        curl_opts="-vvvfL"
+        curl_opts="-vfL"
     fi
     # Invoke healthcheck API and save response
     log_debug "Checking client IP via $IPCHECK_URL"
     {
-        flock --timeout 30 --conflict-exit-code 32 "${__PROTONWIRE_HCR}.lock" \
-            curl "${curl_opts}" -m 30 -A 'protonwire/v7' -o "${__PROTONWIRE_HCR}" \
+        curl "${curl_opts}" -m 30 -A 'protonwire/v7' -o "${__PROTONWIRE_HCR}" \
             "$IPCHECK_URL" 2>&1 | log_tail "curl" &
     }
     wait $!


### PR DESCRIPTION
This also includes docs update for [DNS allowlists/queries](https://github.com/tprasadtp/protonvpn-docker/blob/fix-dns-err-1/docs/faq.md#lanlocal-dns-server-and-api-endpoints) (Closes #238) 
and potentially fix #236.  