### PR TITLE
docs: workarounds when default IPCHECK_URL endpoint is blocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Images are published at [ghcr.io/tprasadtp/protonwire][ghcr].
 
 - Log in to ProtonVPN and go to **Downloads** → **WireGuard configuration**.
 - Enter a name for the key, and select features to enable like NetShield and VPN Accelerator & click create.
+  Some users have reported issues (#236,#211) when NetShield is set to `Block malware, ads and trackers`. Please see [Troubleshooting] for a work-around.
 - Generated config might look something like below,
     ```ini
     [Interface]

--- a/docs/help.md
+++ b/docs/help.md
@@ -14,6 +14,32 @@ Script should take care of that by adding IPs of servers in the same pool to lis
     [ERROR] Failed to verify connection!
     ```
 
+## Unable to verify connection/resolve DNS at https://protonwire-api.vercel.app/v1/client/ip
+
+It appears that ProtonVPN DNS servers are blocking connection to `https://protonwire-api.vercel.app/v1/client/ip` when Netshield option is set to `Block malware, ads and trackers`.
+This IP endpoint simply redirects a valid IPcheck endpoint which works for most users, currently set to `https://icanhazip.com`. It is [controlled by cloudflare and is hosted on cloudflare workers](https://major.io/p/a-new-future-for-icanhazip/). It is not a malware/tracker. Please ask Proton Support to either remove it from their blocklist, use another `IPCHECK_URL` endpoint, or set Netshield option to `Block malware only`
+
+- `https://checkip.amazonaws.com/` (may not work with IPv6 servers)
+- `https://api.ipify.org`
+
+Alternatively, you can host your own `IPCHECK_URL` endpoint on cloudflare workers using the snippet below.
+The snippet below will not work in worker's preview pane as it depends on
+[cf-headers](https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/#cf-connecting-ip), but will work just fine outside of worker's preview pane.
+
+```js
+addEventListener("fetch", (event) => {
+  event.respondWith(
+    handleRequest(event.request).catch(
+      (err) => new Response(err.stack, { status: 500 })
+    )
+  );
+});
+
+async function handleRequest(request) {
+  return new Response(request.headers.get("CF-Connecting-IP"))
+}
+```
+
 ## tmpfs or `/tmp` issues with containers
 
 Please use `tmpfs` mounts for `/tmp`


### PR DESCRIPTION
Provide workaround when default IPCHECK_URL is being blocked by ProtonVPN netshield.
Though asking ProtonVPN to not block might work, provide a work provide a workaround with alternate 
IPCHECK_URL endpoints or via custom cloudflare worker.

Should fix #236, #211 (at-least when using netshield). Thanks @eebette for the diagnosing the issue.